### PR TITLE
New Unit Testing Channel Code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,4 @@ bincode = "1"
 [dev-dependencies]
 env_logger = "0.7.1"
 rand = "0.7.3"
+anyhow = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ bincode = "1"
 env_logger = "0.7.1"
 rand = "0.7.3"
 anyhow = "1.0"
+rusty-fork = { git = "https://github.com/daxpedda/rusty-fork/", rev = "84cb492c2e39f57022e64172d0a97c4305a0c242"}

--- a/src/crossbeam_select.rs
+++ b/src/crossbeam_select.rs
@@ -214,7 +214,7 @@ impl<'a> Select<'a> {
                                         crate::log_rr!(Debug, "No such message found via polling.");
                                         // We failed to find the message we were expecting
                                         // this is a desynchonization.
-                                        return Err(DesyncError::Timedout);
+                                        return Err(DesyncError::Timeout);
                                     }
                                     crate::log_rr!(Debug, "Polling verified message is present.");
                                 }

--- a/src/detthread.rs
+++ b/src/detthread.rs
@@ -76,7 +76,7 @@ pub fn set_temp_det_id(new_id: DetThreadId) {
     });
 }
 
-pub fn start_forwading_id(forwarding_id: DetThreadId) {
+pub fn start_forwarding_id(forwarding_id: DetThreadId) {
     FORWADING_ID.with(|fi| {
         *fi.borrow_mut() = true;
     });

--- a/src/error.rs
+++ b/src/error.rs
@@ -27,7 +27,7 @@ impl From<RecvErrorRR> for DesyncError {
     fn from(e: RecvErrorRR) -> DesyncError {
         match e {
             RecvErrorRR::Disconnected => DesyncError::Disconnected,
-            RecvErrorRR::Timeout => DesyncError::Timedout,
+            RecvErrorRR::Timeout => DesyncError::Timeout,
         }
     }
 }
@@ -63,7 +63,7 @@ pub enum DesyncError {
     /// Expected a message, but channel returned closed.
     ChannelClosedUnexpected(u64),
     /// Waited too long and no message ever came.
-    Timedout,
+    Timeout,
     /// Thread woke up after assuming it had ran of the end of the log.
     /// While `NoEntryInLog` may mean that this thread simply blocked forever
     /// or "didn't make it this far", DesynchronizedWakeup means we put that

--- a/src/ipc_channel/mod.rs
+++ b/src/ipc_channel/mod.rs
@@ -1099,6 +1099,7 @@ mod test {
             }
         }
     }
+
     impl<T: for<'de> Deserialize<'de> + Serialize> TryReceiver<T> for ipc::IpcReceiver<T> {
         type TryRecvError = MyIpcError;
 

--- a/src/ipc_channel/router.rs
+++ b/src/ipc_channel/router.rs
@@ -85,7 +85,7 @@ impl RouterProxy {
                     // DetThreadId is properly forwarded to receiver.
                     let original_id = detthread::get_det_id();
 
-                    detthread::start_forwading_id(forward_id);
+                    detthread::start_forwarding_id(forward_id);
                     callback(Ok(msg));
                     detthread::stop_forwarding_id(original_id);
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ pub mod mpsc;
 mod recordlog;
 mod rr;
 #[cfg(test)]
-mod test;
+pub mod test;
 
 use std::io::Write;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod ipc_channel;
 pub mod mpsc;
 mod recordlog;
 mod rr;
+mod test;
 
 use std::cell::RefCell;
 use std::io::Write;

--- a/src/recordlog.rs
+++ b/src/recordlog.rs
@@ -3,7 +3,6 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs::remove_file;
 use std::fs::File;
-use std::io::BufRead;
 use std::sync::mpsc;
 use std::sync::Mutex;
 

--- a/src/rr.rs
+++ b/src/rr.rs
@@ -60,7 +60,7 @@ impl Default for rr::DetChannelId {
 pub(crate) trait RecvRecordReplay<T, E> {
     /// Given a channel receiver function as a closure (e.g. || receiver.try_receive())
     /// handle the recording or replaying logic for this message arrival.
-    fn record_replay_with(
+    fn record_replay_recv(
         &self,
         mode: &RRMode,
         metadata: &recordlog::RecordMetadata,
@@ -99,11 +99,11 @@ pub(crate) trait RecvRecordReplay<T, E> {
         }
     }
 
-    /// Given the determininistic thread id return the corresponding successful case
+    /// Given the deterministic thread id return the corresponding successful case
     /// of RecordedEvent for record-logging.
     fn recorded_event_succ(dtid: DetThreadId) -> recordlog::RecordedEvent;
 
-    /// Given the channel recieve error, return the corresponding successful case
+    /// Given the channel receive error, return the corresponding successful case
     /// of RecordedEvent for record-logging. We take a reference here as there is no
     /// guarantee that our `E` implements Copy or Clone (like is the case for Ipc Error).
     fn recorded_event_err(e: &E) -> recordlog::RecordedEvent;
@@ -250,7 +250,7 @@ pub(crate) fn recv_expected_message<T>(
 mod test {
     use crate::detthread::{spawn, DetThreadId};
     use crate::rr::{recv_expected_message, DetChannelId};
-    use crate::{init_tivo_thread_root, BufferedValues};
+    use crate::{init_tivo_thread_root, BufferedValues, RRMode};
     use std::borrow::Borrow;
     use std::collections::VecDeque;
 
@@ -330,3 +330,11 @@ mod test {
         assert_eq!(10, bv.get_mut(&sender1).unwrap().pop_back().unwrap());
     }
 }
+
+// #[cfg(test)]
+// mod test {
+//     trait Receiver {
+//         fn recv(&self)
+//     }
+//
+// }

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,129 +1,150 @@
 /// Utility code for unit testing!
-#[cfg(test)]
-mod test {
-    use crate::RRMode;
-    use crate::{crossbeam_channel as cb, init_tivo_thread_root};
-    use anyhow::Result;
-    use std::error::Error;
-    use std::thread;
-    use std::time::Duration;
+use crate::detthread::{get_det_id, DetThreadId};
+use crate::recordlog::{ChannelVariant, RecordEntry, RecordedEvent};
+use crate::rr::DetChannelId;
+use crate::{InMemoryRecorder, RRMode};
+use anyhow::Result;
+use std::collections::HashMap;
+use std::error::Error;
+use std::thread;
+use std::time::Duration;
 
-    /// Interface shared by channels. Allows our test programs to abstract over channel
-    /// type.
-    ///
-    /// Have trait gone too far?
-    trait TestChannel<T> {
-        type S: Sender<T>;
-        type R: Receiver<T>;
-        fn make_channels(mode: RRMode) -> (Self::S, Self::R);
-    }
+pub(crate) trait ThreadSafe: Send + Sync + 'static {}
+impl<T: Send + Sync + 'static> ThreadSafe for T {}
 
-    struct Crossbeam {}
+/// Interface shared by channels. Allows our test programs to abstract over channel
+/// type.
+///
+/// Have trait gone too far?
+pub(crate) trait TestChannel<T> {
+    // Send and 'static needed for channel sender to be moved to different threads.
+    type S: Sender<T> + Send + 'static;
+    type R;
+    fn make_channels(mode: RRMode) -> (Self::S, Self::R);
+}
 
-    impl<T: 'static + Send + Sync> TestChannel<T> for Crossbeam {
-        type S = cb::Sender<T>;
-        type R = cb::Receiver<T>;
+pub(crate) trait Sender<T> {
+    type SendError: Error + ThreadSafe;
+    fn send(&self, msg: T) -> Result<(), Self::SendError>;
+}
 
-        fn make_channels(mode: RRMode) -> (Self::S, Self::R) {
-            cb::unbounded_in_memory(mode)
-        }
-    }
+pub(crate) trait Receiver<T> {
+    type RecvError: Error + ThreadSafe + PartialEq;
 
-    trait Sender<T> {
-        type SendError: 'static + Error + Send + Sync;
-        fn send(&self, msg: T) -> Result<(), Self::SendError>;
-    }
+    fn recv(&self) -> Result<T, Self::RecvError>;
+}
 
-    trait Receiver<T> {
-        type RecvError: 'static + Error + Send + Sync;
-        type TryRecvError: 'static + Error + Send + Sync;
-        type RecvTimeoutError: 'static + Error + Send + Sync;
+pub(crate) trait TryReceiver<T> {
+    type TryRecvError: Error + ThreadSafe + PartialEq;
+    fn try_recv(&self) -> Result<T, Self::TryRecvError>;
 
-        fn recv(&self) -> Result<T, Self::RecvError>;
-        fn try_recv(&self) -> Result<T, Self::TryRecvError>;
+    const EMPTY: Self::TryRecvError;
+    const TRY_DISCONNECTED: Self::TryRecvError;
+}
 
-        const TIMEOUT: Self::RecvTimeoutError;
-        const DISCONNECTED: Self::RecvTimeoutError;
-    }
+pub(crate) trait ReceiverTimeout<T> {
+    type RecvTimeoutError: Error + ThreadSafe + PartialEq;
 
-    impl<T: 'static + Send + Sync> Sender<T> for cb::Sender<T> {
-        type SendError = cb::SendError<T>;
-        fn send(&self, msg: T) -> Result<(), cb::SendError<T>> {
-            self.send(msg)
-        }
-    }
+    fn recv_timeout(&self, timeout: Duration) -> Result<T, Self::RecvTimeoutError>;
 
-    impl<T: 'static + Send + Sync> Receiver<T> for cb::Receiver<T> {
-        type RecvError = cb::RecvError;
-        type TryRecvError = cb::TryRecvError;
-        type RecvTimeoutError = cb::RecvTimeoutError;
+    const TIMEOUT: Self::RecvTimeoutError;
+    const DISCONNECTED: Self::RecvTimeoutError;
+}
 
-        fn recv(&self) -> Result<T, cb::RecvError> {
-            self.recv()
-        }
+pub(crate) fn simple_program<C: TestChannel<i32>>(r: RRMode) -> Result<()>
+where
+    C::R: Receiver<i32>,
+{
+    let (s, r) = C::make_channels(r);
+    s.send(1)?;
+    s.send(3)?;
+    s.send(5)?;
+    r.recv()?;
+    r.recv()?;
+    r.recv()?;
+    Ok(())
+}
 
-        fn try_recv(&self) -> Result<T, cb::TryRecvError> {
-            self.try_recv()
-        }
+pub(crate) fn simple_program_manual_log(
+    send_event: RecordedEvent,
+    recv_event: impl Fn(DetThreadId) -> RecordedEvent,
+    variant: ChannelVariant,
+) -> HashMap<DetThreadId, InMemoryRecorder> {
+    let dti = get_det_id();
+    let channel_id = DetChannelId::from_raw(dti.clone(), 1);
 
-        const TIMEOUT: Self::RecvTimeoutError = cb::RecvTimeoutError::Timeout;
-        const DISCONNECTED: Self::RecvTimeoutError = cb::RecvTimeoutError::Disconnected;
-    }
+    let tn = std::any::type_name::<i32>();
+    let re = RecordEntry::new(send_event, variant, channel_id.clone(), tn.to_string());
 
-    fn simple_program<C: TestChannel<i32>>(r: RRMode) -> Result<()> {
-        // Program which we'll compare logger for.
-        let (s, r) = C::make_channels(r);
-        s.send(1)?;
-        s.send(3)?;
+    let mut rf: InMemoryRecorder = InMemoryRecorder::new(dti.clone());
+    rf.add_entry(re.clone());
+    rf.add_entry(re.clone());
+    rf.add_entry(re);
+
+    let re = RecordEntry::new(recv_event(dti.clone()), variant, channel_id, tn.to_string());
+    rf.add_entry(re.clone());
+    rf.add_entry(re.clone());
+    rf.add_entry(re);
+
+    let mut hm = HashMap::new();
+    hm.insert(dti, rf);
+    hm
+}
+
+pub(crate) fn recv_program<C: TestChannel<i32>>(r: RRMode) -> Result<()>
+where
+    C::R: Receiver<i32>,
+{
+    let (s, r) = C::make_channels(r);
+    let _ = s.send(1)?;
+    let _ = s.send(2)?;
+
+    assert_eq!(r.recv(), Ok(1));
+    assert_eq!(r.recv(), Ok(2));
+    Ok(())
+}
+
+pub(crate) fn try_recv_program<C: TestChannel<i32>>(r: RRMode) -> Result<()>
+where
+    C::R: TryReceiver<i32>,
+{
+    let (s, r) = C::make_channels(r);
+    assert_eq!(r.try_recv(), Err(C::R::EMPTY));
+
+    s.send(5)?;
+    drop(s);
+
+    assert_eq!(r.try_recv(), Ok(5));
+    assert_eq!(r.try_recv(), Err(C::R::TRY_DISCONNECTED));
+    Ok(())
+}
+
+pub(crate) fn recv_timeout_program<C: TestChannel<i32>>(r: RRMode) -> Result<()>
+where
+    C::R: ReceiverTimeout<i32>,
+{
+    let (s, r) = C::make_channels(r);
+
+    let h = crate::detthread::spawn::<_, Result<()>>(move || {
+        thread::sleep(Duration::from_millis(10));
         s.send(5)?;
-        r.recv()?;
-        r.recv()?;
-        r.recv()?;
+        drop(s);
         Ok(())
-    }
+    });
 
-    fn recv_program<C: TestChannel<i32>>(r: RRMode) -> Result<()> {
-        let (s, r) = C::make_channels(r);
-        let _ = s.send(1)?;
-        let _ = s.send(2)?;
+    assert_eq!(
+        r.recv_timeout(Duration::from_micros(10)),
+        Err(C::R::TIMEOUT)
+    );
 
-        assert_eq!(r.recv()?, 1);
-        assert_eq!(r.recv()?, 2);
-        Ok(())
-    }
+    assert_eq!(r.recv_timeout(Duration::from_millis(40)), Ok(5));
+    assert_eq!(
+        r.recv_timeout(Duration::from_millis(50)),
+        Err(C::R::DISCONNECTED)
+    );
 
-    // fn recv_timeout_program<C: TestChannel<i32>>(r: RRMode) -> Result<()> {
-    //     let (s, r) = C::make_channels(r);
-    //
-    //     let h = crate::detthread::spawn::<_, Result<()>>(move || {
-    //         thread::sleep(Duration::from_millis(1));
-    //         s.send(5)?;
-    //         drop(s);
-    //         Ok(())
-    //     });
-    //
-    //     assert_eq!(
-    //         r.recv_timeout(Duration::from_micros(500)),
-    //         Err(C::R::TIMEOUT),
-    //     );
-    //     assert_eq!(r.recv_timeout(Duration::from_millis(1)), Ok(5));
-    //     assert_eq!(r.recv_timeout(Duration::from_millis(1)), Err(C::R::TIMEOUT),);
-    //
-    //     // "Unlike with normal errors, this value doesn't implement the Error trait." So we unwrap
-    //     // instead. Not sure why std::thread::Result doesn't impl Result...
-    //     h.join().unwrap()?;
-    //     Ok(())
-    // }
-
-    #[test]
-    fn foo() {
-        init_tivo_thread_root();
-        simple_program::<Crossbeam>(RRMode::NoRR);
-    }
-
-    #[test]
-    fn foo2() {
-        init_tivo_thread_root();
-        recv_program::<Crossbeam>(RRMode::NoRR);
-    }
+    // "Unlike with normal errors, this value doesn't implement the Error trait." So we unwrap
+    // instead. Not sure why std::thread::Result doesn't impl Result...
+    h.join().unwrap()?;
+    Ok(())
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,0 +1,129 @@
+/// Utility code for unit testing!
+#[cfg(test)]
+mod test {
+    use crate::RRMode;
+    use crate::{crossbeam_channel as cb, init_tivo_thread_root};
+    use anyhow::Result;
+    use std::error::Error;
+    use std::thread;
+    use std::time::Duration;
+
+    /// Interface shared by channels. Allows our test programs to abstract over channel
+    /// type.
+    ///
+    /// Have trait gone too far?
+    trait TestChannel<T> {
+        type S: Sender<T>;
+        type R: Receiver<T>;
+        fn make_channels(mode: RRMode) -> (Self::S, Self::R);
+    }
+
+    struct Crossbeam {}
+
+    impl<T: 'static + Send + Sync> TestChannel<T> for Crossbeam {
+        type S = cb::Sender<T>;
+        type R = cb::Receiver<T>;
+
+        fn make_channels(mode: RRMode) -> (Self::S, Self::R) {
+            cb::unbounded_in_memory(mode)
+        }
+    }
+
+    trait Sender<T> {
+        type SendError: 'static + Error + Send + Sync;
+        fn send(&self, msg: T) -> Result<(), Self::SendError>;
+    }
+
+    trait Receiver<T> {
+        type RecvError: 'static + Error + Send + Sync;
+        type TryRecvError: 'static + Error + Send + Sync;
+        type RecvTimeoutError: 'static + Error + Send + Sync;
+
+        fn recv(&self) -> Result<T, Self::RecvError>;
+        fn try_recv(&self) -> Result<T, Self::TryRecvError>;
+
+        const TIMEOUT: Self::RecvTimeoutError;
+        const DISCONNECTED: Self::RecvTimeoutError;
+    }
+
+    impl<T: 'static + Send + Sync> Sender<T> for cb::Sender<T> {
+        type SendError = cb::SendError<T>;
+        fn send(&self, msg: T) -> Result<(), cb::SendError<T>> {
+            self.send(msg)
+        }
+    }
+
+    impl<T: 'static + Send + Sync> Receiver<T> for cb::Receiver<T> {
+        type RecvError = cb::RecvError;
+        type TryRecvError = cb::TryRecvError;
+        type RecvTimeoutError = cb::RecvTimeoutError;
+
+        fn recv(&self) -> Result<T, cb::RecvError> {
+            self.recv()
+        }
+
+        fn try_recv(&self) -> Result<T, cb::TryRecvError> {
+            self.try_recv()
+        }
+
+        const TIMEOUT: Self::RecvTimeoutError = cb::RecvTimeoutError::Timeout;
+        const DISCONNECTED: Self::RecvTimeoutError = cb::RecvTimeoutError::Disconnected;
+    }
+
+    fn simple_program<C: TestChannel<i32>>(r: RRMode) -> Result<()> {
+        // Program which we'll compare logger for.
+        let (s, r) = C::make_channels(r);
+        s.send(1)?;
+        s.send(3)?;
+        s.send(5)?;
+        r.recv()?;
+        r.recv()?;
+        r.recv()?;
+        Ok(())
+    }
+
+    fn recv_program<C: TestChannel<i32>>(r: RRMode) -> Result<()> {
+        let (s, r) = C::make_channels(r);
+        let _ = s.send(1)?;
+        let _ = s.send(2)?;
+
+        assert_eq!(r.recv()?, 1);
+        assert_eq!(r.recv()?, 2);
+        Ok(())
+    }
+
+    // fn recv_timeout_program<C: TestChannel<i32>>(r: RRMode) -> Result<()> {
+    //     let (s, r) = C::make_channels(r);
+    //
+    //     let h = crate::detthread::spawn::<_, Result<()>>(move || {
+    //         thread::sleep(Duration::from_millis(1));
+    //         s.send(5)?;
+    //         drop(s);
+    //         Ok(())
+    //     });
+    //
+    //     assert_eq!(
+    //         r.recv_timeout(Duration::from_micros(500)),
+    //         Err(C::R::TIMEOUT),
+    //     );
+    //     assert_eq!(r.recv_timeout(Duration::from_millis(1)), Ok(5));
+    //     assert_eq!(r.recv_timeout(Duration::from_millis(1)), Err(C::R::TIMEOUT),);
+    //
+    //     // "Unlike with normal errors, this value doesn't implement the Error trait." So we unwrap
+    //     // instead. Not sure why std::thread::Result doesn't impl Result...
+    //     h.join().unwrap()?;
+    //     Ok(())
+    // }
+
+    #[test]
+    fn foo() {
+        init_tivo_thread_root();
+        simple_program::<Crossbeam>(RRMode::NoRR);
+    }
+
+    #[test]
+    fn foo2() {
+        init_tivo_thread_root();
+        recv_program::<Crossbeam>(RRMode::NoRR);
+    }
+}


### PR DESCRIPTION
Implements channel-agnostic tests which can be executed against all 3 channel implementations we currently support: `crossbeam`, `mpsc`, and `ipc`. 